### PR TITLE
U16 and u32

### DIFF
--- a/Cpp/fost-core/string-utilities.cpp
+++ b/Cpp/fost-core/string-utilities.cpp
@@ -295,7 +295,7 @@ nullable<string> fostlib::concat(
     else if (not right)
         return left;
     else
-        return left.value() + mid + right.value();
+        return f5::u8view{left.value() + mid} + right.value();
 }
 nullable<string> fostlib::concat(
         const nullable<f5::u8view> &left, const nullable<f5::u8view> &right) {

--- a/Cpp/fost-crypto/jwt.cpp
+++ b/Cpp/fost-crypto/jwt.cpp
@@ -109,12 +109,12 @@ std::string fostlib::jws::sign_base64_string(
         hmac digester{sha256, key};
         digester << header_b64 << "." << payload_b64;
         return static_cast<std::string>(
-                header_b64 + "." + payload_b64 + "."
+                f5::u8view{header_b64 + "."} + payload_b64 + "."
                 + base64url(digester.digest()));
     }
     case alg::EdDSA: {
         ed25519::keypair const kp{key};
-        auto const b64 = header_b64 + "." + payload_b64;
+        auto const b64 = f5::u8view{header_b64 + "."} + payload_b64;
         auto const signature = kp.sign(f5::buffer<const f5::byte>{
                 reinterpret_cast<unsigned char const *>(b64.data()),
                 b64.bytes()});

--- a/Cpp/include/fost/string.hpp
+++ b/Cpp/include/fost/string.hpp
@@ -108,6 +108,12 @@ namespace fostlib {
 
         /// ### String operations
         string operator+(f5::u8view v) const { return f5::u8view{*this} + v; }
+        string operator+(f5::lstring v) const {
+            return f5::u8view{*this} + f5::u8view{v};
+        }
+        string operator+(string const &v) const {
+            return f5::u8view{*this} + f5::u8view{v};
+        }
         string operator+(char32_t) const;
         string operator+(nliteral r) const {
             return f5::u8view{*this} + f5::u8view{r, std::strlen(r)};
@@ -208,6 +214,12 @@ namespace fostlib {
     /// ### Binary operators needed outside of the class
     inline bool operator==(f5::lstring l, const string &r) {
         return r == f5::u8view{l};
+    }
+    inline f5::u8string operator+(f5::u8view l, string const &r) {
+        return l + f5::u8view{r};
+    }
+    inline f5::u8string operator+(f5::u8string l, string const &r) {
+        return f5::u8view{l} + f5::u8view{r};
     }
     inline bool operator==(nliteral l, const string &r) { return r == l; }
     inline bool operator==(wliteral l, const string &r) { return r == l; }

--- a/Cpp/include/fost/string.hpp
+++ b/Cpp/include/fost/string.hpp
@@ -212,6 +212,14 @@ namespace fostlib {
 
 
     /// ### Binary operators needed outside of the class
+    template<std::size_t N>
+    inline bool operator==(const char (&l)[N], string const &r) {
+        return r == l;
+    }
+    template<std::size_t N>
+    inline bool operator!=(const char (&l)[N], string const &r) {
+        return r != l;
+    }
     inline bool operator==(f5::lstring l, const string &r) {
         return r == f5::u8view{l};
     }

--- a/Cpp/include/fost/tagged-string.hpp
+++ b/Cpp/include/fost/tagged-string.hpp
@@ -154,6 +154,14 @@ namespace fostlib {
 
 
     template<typename T, typename I>
+    inline auto operator==(std::string const &l, tagged_string<T, I> const &r) {
+        return l == f5::u8view{r};
+    }
+    template<typename T, typename I>
+    inline auto operator!=(std::string const &l, tagged_string<T, I> const &r) {
+        return l != f5::u8view{r};
+    }
+    template<typename T, typename I>
     inline auto operator+(f5::u8string l, tagged_string<T, I> const &r) {
         return tagged_string<T, I>{f5::u8view{l} + f5::u8view{r}};
     }

--- a/Cpp/include/fost/tagged-string.hpp
+++ b/Cpp/include/fost/tagged-string.hpp
@@ -118,6 +118,14 @@ namespace fostlib {
             m_string += c;
             return *this;
         }
+        tagged_string &operator+=(f5::u8view const c) {
+            return operator+=(tagged_string{c});
+        }
+        tagged_string &operator+=(string const &c) {
+            tag_type::check_encoded(c);
+            m_string += c;
+            return *this;
+        }
         tagged_string &operator+=(const tagged_string &s) {
             m_string += s.m_string;
             return *this;
@@ -143,6 +151,21 @@ namespace fostlib {
             return static_cast<std::string_view>(m_string);
         }
     };
+
+
+    template<typename T, typename I>
+    inline auto operator+(f5::u8string l, tagged_string<T, I> const &r) {
+        return tagged_string<T, I>{f5::u8view{l} + f5::u8view{r}};
+    }
+    template<typename T, typename I>
+    inline auto operator+(string const &l, tagged_string<T, I> const &r) {
+        return tagged_string<T, I>{f5::u8view{l} + f5::u8view{r}};
+    }
+    template<typename T, typename I>
+    inline decltype(auto)
+            operator+=(std::string &s, tagged_string<T, I> const &t) {
+        return s += std::string_view{t};
+    }
 
 
     template<typename T, typename I>


### PR DESCRIPTION
These are a few small changes that will be needed to support the changes in cord that turn the `f5::u8view` and `f5::u8string` into templates so we can also have the other UTF sizes we want (16 and 32).