### PR TITLE
Libc++9

### DIFF
--- a/Cpp/fost-core/jcursor.cpp
+++ b/Cpp/fost-core/jcursor.cpp
@@ -43,7 +43,9 @@ bool fostlib::operator==(const fostlib::jcursor::value_type &lhs, nliteral rhs) 
 
 
 fostlib::jcursor::jcursor() {}
-fostlib::jcursor::jcursor(int i) { m_position.push_back(i); }
+fostlib::jcursor::jcursor(int i) {
+    m_position.push_back(fostlib::coerce<std::size_t>(i));
+}
 fostlib::jcursor::jcursor(json::array_t::size_type i) {
     m_position.push_back(i);
 }
@@ -108,7 +110,7 @@ fostlib::jcursor &fostlib::jcursor::operator/=(const jcursor &r) {
 }
 
 fostlib::jcursor &fostlib::jcursor::enter() {
-    m_position.push_back(0);
+    m_position.push_back(0u);
     return *this;
 }
 fostlib::jcursor &fostlib::jcursor::enter(const string &i) {

--- a/Cpp/fost-core/string.cpp
+++ b/Cpp/fost-core/string.cpp
@@ -136,10 +136,11 @@ char32_t fostlib::string::at(std::size_t p) const {
 }
 
 
-fostlib::string::size_type fostlib::string::find(char32_t const f) const {
+fostlib::string::size_type
+        fostlib::string::find(char32_t const f, std::size_t s) const {
     size_type index{};
     for (char32_t c : *this) {
-        if (c == f) { return index; }
+        if (index >= s && c == f) { return index; }
         ++index;
     }
     return npos;

--- a/Cpp/include/fost/detail/utility.hpp
+++ b/Cpp/include/fost/detail/utility.hpp
@@ -19,6 +19,9 @@ namespace fostlib {
 
     typedef std::vector<string> split_type;
     FOST_CORE_DECLSPEC split_type split(const string &text, const string &on);
+    inline split_type split(const string &text, char32_t c) {
+        return split(text, string{c});
+    }
 
 
     /// Return a GUID as a string

--- a/Cpp/include/fost/json.hpp
+++ b/Cpp/include/fost/json.hpp
@@ -110,7 +110,7 @@ namespace fostlib {
 
         /// Append operators
         jcursor &operator/=(int i) {
-            return (*this) /= json::array_t::size_type(i);
+            return (*this) /= fostlib::coerce<json::array_t::size_type>(i);
         }
         jcursor &operator/=(json::array_t::size_type i);
         jcursor &operator/=(nliteral n) {
@@ -124,12 +124,8 @@ namespace fostlib {
         jcursor &operator/=(const jcursor &jc);
 
         template<typename T>
-        jcursor operator/(const T &i) const & {
-            return jcursor(*this) /= i;
-        }
-        template<typename T>
-        jcursor &&operator/(const T &i) && {
-            return std::move((*this) /= i);
+        jcursor operator/(T &&i) const {
+            return jcursor(*this) /= std::forward<T>(i);
         }
 
         jcursor &enter();
@@ -196,11 +192,11 @@ namespace fostlib {
 
         template<typename A1>
         void append(A1 &&a1) {
-            (*this) /= jcursor(std::forward<A1>(a1));
+            (*this) /= jcursor{std::forward<A1>(a1)};
         }
         template<typename A1, typename... As>
         void append(A1 &&a1, As &&... a) {
-            (*this) /= jcursor(std::forward<A1>(a1));
+            (*this) /= jcursor{std::forward<A1>(a1)};
             append(std::forward<As>(a)...);
         }
     };

--- a/Cpp/include/fost/string.hpp
+++ b/Cpp/include/fost/string.hpp
@@ -45,7 +45,7 @@ namespace fostlib {
         explicit string(std::string_view s) : string{std::string{s}} {}
         string(nliteral s) : f5::u8string{std::string(s)} {}
         string(wliteral);
-        string(wchar_t c) : string{1u, char32_t(c)} {}
+        explicit string(char32_t c) : string{1u, char32_t(c)} {}
 
         string(size_type, char32_t);
 
@@ -162,8 +162,9 @@ namespace fostlib {
         bool operator>=(wliteral) const;
 
         /// ### Algorithmic APIs
-        size_type find(char32_t) const;
+        size_type find(char32_t, size_type = 0u) const;
         size_type find(const string &, size_type = 0u) const;
+        size_type find_first_of(char32_t c) const { return find(c); }
         size_type find_first_of(const string &) const;
         size_type find_first_not_of(const string &) const;
         size_type find_last_not_of(const string &) const;
@@ -171,10 +172,14 @@ namespace fostlib {
         bool startswith(const string &s) const {
             return starts_with(f5::u8view{s});
         }
+        bool startswith(char32_t c) const {
+            return not empty() && *begin() == c;
+        }
         using f5::u8string::ends_with;
         bool endswith(const string &s) const {
             return ends_with(f5::u8view{s});
         }
+        bool endswith(char32_t c) const { return ends_with(string{c}); }
 
         /// ### Mutation APIs (to be deprecated)
         string &operator+=(wchar_t c) { return *this = (*this + c); }


### PR DESCRIPTION
Doing some test compiles with libc++9 a load of the `jcursor` tests started to fail in very strange ways.

It turns out that the `index_t` type it uses (a variant, effectively `std::variant<std::size_t, fostlib::string>`) does an odd thing in that version of the library. When passed some integral types like `int`, instead of promoting to a `std::size_t` it found a `string` constructor that took a `wchar_t` and used that instead!

The solution is to make that constructor `explicit` (as it always should have been), and BTW, to make it a `char32_t` now that that's a thing.

There are also some follow on changes from that. There are places where more efficient implementations could be done, but the current code is no worse than the previous version and in some cases better. Also fix up some constructors in the `jcursor` class to make it a little bit more obvious what is expected to happen.