### PR TITLE
Have `json` store the string directly rather than as a `shared_ptr`.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-12-26  Kirit Saelensminde  <kirit@felspar.com>
+ Have `json` store the string directly rather than as a `shared_ptr`. This is a breaking change on `json` visitors.
+
 2019-12-10  Kirit Saelensminde  <kirit@felspar.com>
  * Add source file and line/column numbers to `parse_error`.
  * Improve the `jcursor` API so it can mutate `json` more efficiently.

--- a/Cpp/fost-cli/logger-stdio.cpp
+++ b/Cpp/fost-cli/logger-stdio.cpp
@@ -21,11 +21,8 @@ namespace {
         std::ostream &channel;
 
         template<typename T>
-        void operator()(const T &t) const {
+        void operator()(T const &t) const {
             channel << nl_space << t << '\n' << std::endl;
-        }
-        void operator()(fostlib::json::string_p u) {
-            channel << nl_space << *u << '\n' << std::endl;
         }
         void operator()(const fostlib::json::object_p &o) const {
             if (o->find(fostlib::string()) != o->end()) {

--- a/Cpp/fost-core/filesystem-path.tests.cpp
+++ b/Cpp/fost-core/filesystem-path.tests.cpp
@@ -15,13 +15,13 @@ FSL_TEST_SUITE(boost_filesystem_path);
 
 FSL_TEST_FUNCTION(coercion_string) {
     fostlib::fs::path p(L"somefilepath");
-    FSL_CHECK_EQ(fostlib::coerce<fostlib::string>(p), L"somefilepath");
+    FSL_CHECK_EQ(fostlib::coerce<fostlib::string>(p), "somefilepath");
 }
 
 
 FSL_TEST_FUNCTION(coercion_json) {
     fostlib::fs::path p(L"somefilepath");
-    fostlib::json j(L"somefilepath");
+    fostlib::json j("somefilepath");
     FSL_CHECK_EQ(fostlib::coerce<fostlib::json>(p), j);
     FSL_CHECK_EQ(fostlib::coerce<fostlib::fs::path>(j), p);
 }

--- a/Cpp/fost-core/json-coerce.cpp
+++ b/Cpp/fost-core/json-coerce.cpp
@@ -27,9 +27,7 @@ namespace {
         bool operator()(int64_t i) const { return i; }
         bool operator()(double d) const { return d != 0.; }
         bool operator()(f5::lstring s) const { return not s.empty(); }
-        bool operator()(const json::string_p &s) const {
-            return not s->empty();
-        }
+        bool operator()(const json::string_t &s) const { return not s.empty(); }
         bool operator()(const json::array_p &a) const { return a->size(); }
         bool operator()(const json::object_p &o) const { return o->size(); }
     };
@@ -51,8 +49,8 @@ namespace {
         int64_t operator()(int64_t i) const { return i; }
         int64_t operator()(double d) const { return int64_t(d); }
         int64_t operator()(f5::lstring s) const { return coerce<int64_t>(s); }
-        int64_t operator()(const json::string_p &s) const {
-            return coerce<int64_t>(*s);
+        int64_t operator()(json::string_t const &s) const {
+            return coerce<int64_t>(s);
         }
         int64_t operator()(const json::array_p &) const {
             throw fostlib::exceptions::not_a_number(
@@ -81,8 +79,8 @@ namespace {
         double operator()(int64_t i) const { return double(i); }
         double operator()(double d) const { return d; }
         double operator()(f5::lstring s) const { return coerce<double>(s); }
-        double operator()(const json::string_p &s) const {
-            return coerce<double>(*s);
+        double operator()(const json::string_t &s) const {
+            return coerce<double>(s);
         }
         double operator()(const json::array_p &) const {
             throw fostlib::exceptions::not_a_number(
@@ -121,8 +119,8 @@ namespace {
                     "Cannot convert double to f5::u8view");
         }
         f5::u8view operator()(f5::lstring s) const { return f5::u8view(s); }
-        f5::u8view operator()(const json::string_p &s) const {
-            return f5::u8view(*s);
+        f5::u8view operator()(json::string_t const &s) const {
+            return f5::u8view{s};
         }
         f5::u8view operator()(json::array_p const &a) const {
             fostlib::exceptions::cast_fault error(
@@ -150,8 +148,8 @@ namespace {
         nullable<f5::u8view> operator()(f5::lstring s) const {
             return f5::u8view(s);
         }
-        nullable<f5::u8view> operator()(const json::string_p &s) const {
-            return f5::u8view(*s);
+        nullable<f5::u8view> operator()(json::string_t const &s) const {
+            return f5::u8view{s};
         }
         nullable<f5::u8view> operator()(const json::array_p &) const {
             return null;
@@ -174,7 +172,7 @@ namespace {
         string operator()(int64_t i) const { return coerce<string>(i); }
         string operator()(double d) const { return coerce<string>(d); }
         string operator()(f5::lstring s) const { return string(s); }
-        string operator()(const json::string_p &s) const { return *s; }
+        string operator()(json::string_t const &s) const { return s; }
         string operator()(const json::array_p &a) const {
             fostlib::exceptions::cast_fault error(
                     "Cannot convert a JSON array to a string");

--- a/Cpp/fost-core/json-order.cpp
+++ b/Cpp/fost-core/json-order.cpp
@@ -55,8 +55,8 @@ namespace {
             return false;
         }
         bool operator()(f5::lstring right) const { return left < right; }
-        bool operator()(const fostlib::json::string_p &right) const {
-            return left < *right;
+        bool operator()(fostlib::json::string_t const &right) const {
+            return left < right;
         }
         bool operator()(const fostlib::json::array_p &) const { return true; }
         bool operator()(const fostlib::json::object_p &) const { return true; }
@@ -115,8 +115,8 @@ namespace {
         bool operator()(f5::lstring left) const {
             return right.apply_visitor(::compare_u8view(left));
         }
-        bool operator()(const fostlib::json::string_p &left) const {
-            return right.apply_visitor(::compare_u8view(*left));
+        bool operator()(const fostlib::json::string_t &left) const {
+            return right.apply_visitor(::compare_u8view(left));
         }
         bool operator()(const fostlib::json::array_p &left) const {
             return right.apply_visitor(::compare_array(*left));

--- a/Cpp/fost-core/json-unparse.cpp
+++ b/Cpp/fost-core/json-unparse.cpp
@@ -76,8 +76,8 @@ namespace {
                     fostlib::coerce<fostlib::string>(d));
         }
         void operator()(f5::lstring s) const { string_to_json(into, s); }
-        void operator()(const json::string_p &s) const {
-            string_to_json(into, *s);
+        void operator()(const json::string_t &s) const {
+            string_to_json(into, s);
         }
         void operator()(const json::array_p &t) const {
             into += '[';

--- a/Cpp/fost-core/json.cpp
+++ b/Cpp/fost-core/json.cpp
@@ -93,9 +93,9 @@ namespace {
             auto rvp = std::get_if<T>(&r);
             return rvp && t == *rvp;
         }
-        bool operator()(const json::string_p &t) const {
-            auto rvp = std::get_if<json::string_p>(&r);
-            return rvp && *t == **rvp;
+        bool operator()(json::string_t const &t) const {
+            auto rvp = std::get_if<json::string_t>(&r);
+            return rvp && t == *rvp;
         }
         bool operator()(const json::array_p &ta) const {
             if (!std::get_if<json::array_p>(&r))
@@ -132,7 +132,7 @@ namespace {
     struct comparator_string {
         f5::u8view with;
         bool operator()(f5::lstring s) { return s == with; }
-        bool operator()(const json::string_p &s) { return *s == with; }
+        bool operator()(json::string_t const &s) { return s == with; }
         template<typename T>
         bool operator()(const T &) {
             return false;

--- a/Cpp/include/fost/detail/coerce.hpp
+++ b/Cpp/include/fost/detail/coerce.hpp
@@ -31,6 +31,15 @@ namespace fostlib {
     };
 
 
+    /// In all cases, we can treat a `u8string` source as a `u8view`
+    template<typename T>
+    struct coercer<T, f5::u8string> {
+        T coerce(f5::u8view s) {
+            return fostlib::coercer<T, f5::u8view>{}.coerce(s);
+        }
+    };
+
+
     /// Coerce fostlib::exceptions::exception instances to a string
     template<typename E>
     struct coercer<

--- a/Cpp/include/fost/json-core.hpp
+++ b/Cpp/include/fost/json-core.hpp
@@ -33,7 +33,7 @@ namespace fostlib {
         friend class jcursor;
 
       public:
-        using string_p = std::shared_ptr<string>;
+        using string_t = f5::u8string;
         using array_t = json_array;
         using array_p = std::shared_ptr<array_t>;
         using object_t = json_object;
@@ -44,7 +44,7 @@ namespace fostlib {
                 int64_t,
                 double,
                 f5::lstring,
-                string_p,
+                string_t,
                 array_p,
                 object_p>;
 
@@ -69,14 +69,14 @@ namespace fostlib {
              std::enable_if_t<std::is_integral<I>::value, void *> = nullptr)
         : m_element(int64_t(i)) {}
         explicit json(double d) : m_element(d) {}
-        explicit json(const char *s) : m_element(std::make_shared<string>(s)) {}
-        explicit json(const wchar_t *s)
-        : m_element(std::make_shared<string>(s)) {}
-        explicit json(string s)
-        : m_element(std::make_shared<string>(std::move(s))) {}
-        explicit json(string_p s) : m_element(s) {}
+        explicit json(const char *s) : m_element(string_t{s}) {}
+        [[deprecated("Do not use wchar_t literals")]] explicit json(
+                const wchar_t *s)
+        : m_element(string{s}.u8string_transition()) {}
+        explicit json(string s) : m_element(s.u8string_transition()) {}
+        explicit json(string_t s) : m_element(std::move(s)) {}
         json(f5::lstring s) : m_element(s) {}
-        json(f5::u8view s) : m_element(std::make_shared<string>(s)) {}
+        json(f5::u8view s) : m_element(string_t{s}) {}
         json(const array_t &a) : m_element(std::make_shared<array_t>(a)) {}
         json(array_t &&a)
         : m_element(std::make_shared<array_t>(std::move(a))) {}
@@ -176,19 +176,20 @@ namespace fostlib {
             return *this;
         }
         json &operator=(const char *s) {
-            m_element = std::make_shared<string>(s);
+            m_element = string_t{s};
             return *this;
         }
-        json &operator=(const wchar_t *s) {
-            m_element = std::make_shared<string>(s);
+        [[deprecated("Do not use wchar_t literals")]] json &
+                operator=(const wchar_t *s) {
+            m_element = string{s}.u8string_transition();
             return *this;
         }
         json &operator=(const string &s) {
-            m_element = std::make_shared<string>(s);
+            m_element = s.u8string_transition();
             return *this;
         }
         json &operator=(string &&s) {
-            m_element = std::make_shared<string>(std::move(s));
+            m_element = s.u8string_transition();
             return *this;
         }
         json &operator=(const array_t &a) {

--- a/Cpp/include/fost/json.hpp
+++ b/Cpp/include/fost/json.hpp
@@ -22,21 +22,22 @@ namespace fostlib {
 
     template<>
     inline json::json(const nullable<string> &s) : m_element() {
-        if (s) m_element = std::make_shared<string>(*s);
+        if (s) m_element = s->u8string_transition();
     }
     template<>
     inline json::json(nullable<string> &&s) : m_element() {
-        if (s) m_element = std::make_shared<string>(std::move(*s));
+        if (s) m_element = s->u8string_transition();
     }
 
     template<>
     [[deprecated("Use f5::u8view instead")]] inline nullable<string>
             json::get() const {
-        const string_p *p = std::get_if<string_p>(&m_element);
-        if (p)
-            return **p;
-        else
+        string_t const *p = std::get_if<string_t>(&m_element);
+        if (p) {
+            return *p;
+        } else {
             return null;
+        }
     }
 
     template<>

--- a/Cpp/include/fost/string.hpp
+++ b/Cpp/include/fost/string.hpp
@@ -258,17 +258,6 @@ namespace fostlib {
 }
 
 
-#ifdef FOST_COERCE_HPP
-#include <fost/string/coerce.hpp>
-#endif
-#ifdef FOST_ACCESSORS_HPP
-#include <fost/string/accessors.hpp>
-#endif
-#ifdef FOST_NULLABLE_HPP
-#include <fost/string/nullable.hpp>
-#endif
-
-
 namespace std {
 
 

--- a/Cpp/include/fost/unicode.hpp
+++ b/Cpp/include/fost/unicode.hpp
@@ -135,9 +135,9 @@ namespace fostlib {
     /// Implementation for fetching u8view from JSON instance
     template<>
     inline nullable<f5::u8view> json::get() const {
-        string_p const *const p = std::get_if<string_p>(&m_element);
+        string_t const *const p = std::get_if<string_t>(&m_element);
         if (p) {
-            return **p;
+            return *p;
         } else {
             f5::lstring const *const ls = std::get_if<f5::lstring>(&m_element);
             if (ls) return *ls;


### PR DESCRIPTION
Remove an extra level indirection in the JSON implementation we no longer need now that strings are always shared.