### PR TITLE
Feature/jcursor push back

### DIFF
--- a/Cpp/fost-core/jcursor.cpp
+++ b/Cpp/fost-core/jcursor.cpp
@@ -206,10 +206,13 @@ fostlib::json &fostlib::jcursor::push_back(json &j, json &&v) const {
         na.push_back(std::move(v));
         array = na;
     } else if (array.isarray()) {
-        std::get<json::array_p>(array.m_element)->push_back(v);
-    } else
+        fostlib::json::array_t copy{array.begin(), array.end()};
+        copy.push_back(std::move(v));
+        array = std::move(copy);
+    } else {
         throw exceptions::json_error(
                 "Can only push onto the back of a JSON array");
+    }
     return j;
 }
 

--- a/Cpp/fost-core/json-jcursor-tests.cpp
+++ b/Cpp/fost-core/json-jcursor-tests.cpp
@@ -113,6 +113,10 @@ FSL_TEST_FUNCTION(push_back) {
     FSL_CHECK_EQ(j2["key1"]["key2"][0], data);
     FSL_CHECK_NOTHROW(fostlib::push_back(j2, "key1", "key2", j1));
     FSL_CHECK_EQ(j2["key1"]["key2"][1], j1);
+
+    fostlib::json j3{fostlib::json::array_t{}};
+    fostlib::jcursor{}.push_back(j3, "v1");
+    FSL_CHECK_EQ(j3.size(), 1u);
 }
 
 

--- a/Cpp/fost-core/json-jcursor-tests.cpp
+++ b/Cpp/fost-core/json-jcursor-tests.cpp
@@ -116,7 +116,10 @@ FSL_TEST_FUNCTION(push_back) {
 
     fostlib::json j3{fostlib::json::array_t{}};
     fostlib::jcursor{}.push_back(j3, "v1");
-    FSL_CHECK_EQ(j3.size(), 1u);
+    fostlib::jcursor{}.push_back(j3, "v2");
+    FSL_CHECK_EQ(j3.size(), 2u);
+    FSL_CHECK_EQ(j3[0], "v1");
+    FSL_CHECK_EQ(j3[1], "v2");
 }
 
 

--- a/Cpp/fost-core/json-jcursor-tests.cpp
+++ b/Cpp/fost-core/json-jcursor-tests.cpp
@@ -44,14 +44,14 @@ FSL_TEST_FUNCTION(equality) {
 
 FSL_TEST_FUNCTION(non_empty) {
     fostlib::json a = fostlib::json(fostlib::json::object_t());
-    fostlib::jcursor("key")(a) = fostlib::json(10);
+    fostlib::jcursor("key").set(a, 10);
 
     FSL_CHECK_EQ(a[fostlib::jcursor()], a);
     FSL_CHECK_EQ(a[fostlib::jcursor("key")], fostlib::json(10));
 
     fostlib::json b = fostlib::json(fostlib::json::array_t());
-    fostlib::jcursor(0)(b) = fostlib::json(10);
-    fostlib::jcursor(1)(b) = fostlib::json(20);
+    fostlib::jcursor(0).set(b, 10);
+    fostlib::jcursor(1).set(b, 20);
 
     FSL_CHECK_EQ(b[fostlib::jcursor()], b);
     FSL_CHECK_EQ(b[fostlib::jcursor(0)], fostlib::json(10));
@@ -61,11 +61,11 @@ FSL_TEST_FUNCTION(non_empty) {
 
 FSL_TEST_FUNCTION(json_position) {
     fostlib::json a = fostlib::json(fostlib::json::object_t());
-    fostlib::jcursor("key")(a) = fostlib::json(123);
+    fostlib::jcursor("key").set(a, 123);
     fostlib::json b = fostlib::json(fostlib::json::array_t());
-    fostlib::jcursor(0)(b) = fostlib::json(10);
-    fostlib::jcursor(1)(b) = fostlib::json(20);
-    fostlib::jcursor(2)(b) = a;
+    fostlib::jcursor(0).set(b, 10);
+    fostlib::jcursor(1).set(b, 20);
+    fostlib::jcursor(2).set(b, a);
     FSL_CHECK_EQ(a[fostlib::jcursor(fostlib::json("key"))], fostlib::json(123));
     FSL_CHECK_EQ(b[fostlib::jcursor(fostlib::json(0))], fostlib::json(10));
     FSL_CHECK_EQ(b[fostlib::jcursor(fostlib::json(1))], fostlib::json(20));
@@ -75,22 +75,22 @@ FSL_TEST_FUNCTION(json_position) {
 
 FSL_TEST_FUNCTION(updates) {
     fostlib::json j;
-    FSL_CHECK_NOTHROW(fostlib::jcursor("key")(j) = fostlib::json("value"));
+    FSL_CHECK_NOTHROW(fostlib::jcursor("key").set(j, "value"));
     FSL_CHECK_EQ(j["key"], fostlib::json("value"));
     FSL_CHECK_EXCEPTION(
-            (fostlib::jcursor("key") / "1st")(j),
+            j[fostlib::jcursor("key") / "1st"],
             fostlib::exceptions::json_error &);
     FSL_CHECK_NOTHROW(
-            (fostlib::jcursor("key2") / "1st")(j) = fostlib::json("value 1"));
+            (fostlib::jcursor("key2") / "1st").set(j, "value 1"));
     FSL_CHECK_NOTHROW(
-            (fostlib::jcursor("key2") / "2nd")(j) = fostlib::json("value 2"));
+            (fostlib::jcursor("key2") / "2nd").set(j, "value 2"));
     FSL_CHECK_EQ(j["key"], fostlib::json("value"));
     FSL_CHECK_EQ(j["key2"]["1st"], fostlib::json("value 1"));
     FSL_CHECK_EQ(j["key2"]["2nd"], fostlib::json("value 2"));
     FSL_CHECK_NOTHROW(
-            (fostlib::jcursor("key3") / 0)(j) = fostlib::json("value x"));
+            (fostlib::jcursor("key3") / 0).set(j, "value x"));
     FSL_CHECK_NOTHROW(
-            (fostlib::jcursor("key3") / 1)(j) = fostlib::json("value y"));
+            (fostlib::jcursor("key3") / 1).set(j, "value y"));
     FSL_CHECK_EQ(j["key"], fostlib::json("value"));
     FSL_CHECK_EQ(j["key2"]["1st"], fostlib::json("value 1"));
     FSL_CHECK_EQ(j["key2"]["2nd"], fostlib::json("value 2"));

--- a/Cpp/fost-core/json-jcursor-tests.cpp
+++ b/Cpp/fost-core/json-jcursor-tests.cpp
@@ -116,10 +116,16 @@ FSL_TEST_FUNCTION(push_back) {
 
     fostlib::json j3{fostlib::json::array_t{}};
     fostlib::jcursor{}.push_back(j3, "v1");
-    fostlib::jcursor{}.push_back(j3, "v2");
-    FSL_CHECK_EQ(j3.size(), 2u);
+    FSL_CHECK_EQ(j3.size(), 1u);
     FSL_CHECK_EQ(j3[0], "v1");
-    FSL_CHECK_EQ(j3[1], "v2");
+
+    fostlib::json j4{j3};
+    fostlib::jcursor{}.push_back(j4, "v2");
+    FSL_CHECK_EQ(j3.size(), 1u);
+    FSL_CHECK_EQ(j3[0], "v1");
+    FSL_CHECK_EQ(j4.size(), 2u);
+    FSL_CHECK_EQ(j4[0], "v1");
+    FSL_CHECK_EQ(j4[1], "v2");
 }
 
 

--- a/Cpp/fost-core/json-object-basic-tests.cpp
+++ b/Cpp/fost-core/json-object-basic-tests.cpp
@@ -63,11 +63,11 @@ FSL_TEST_FUNCTION(insert) {
 
 FSL_TEST_FUNCTION(set) {
     fostlib::json a = fostlib::json::object_t();
-    FSL_CHECK_NOTHROW(fostlib::jcursor("key")(a) = fostlib::json("value"));
+    FSL_CHECK_NOTHROW(fostlib::jcursor("key").set(a, "value"));
     FSL_CHECK_EQ(a.size(), 1u);
     FSL_CHECK_EQ(a["key"], fostlib::json("value"));
-    FSL_CHECK_NOTHROW(fostlib::jcursor("key 2")(a) = fostlib::json(10));
-    FSL_CHECK_NOTHROW(fostlib::jcursor("key 2")(a) = fostlib::json(12));
+    FSL_CHECK_NOTHROW(fostlib::jcursor("key 2").set(a, 10));
+    FSL_CHECK_NOTHROW(fostlib::jcursor("key 2").set(a, 12));
     FSL_CHECK_EQ(a.size(), 2u);
     FSL_CHECK_EQ(a["key 2"], fostlib::json(12));
 }
@@ -82,7 +82,7 @@ FSL_TEST_FUNCTION(replace) {
             fostlib::jcursor("key 2").replace(a, 10),
             fostlib::exceptions::null &);
     fostlib::jcursor("key 2").insert(a, 10);
-    fostlib::jcursor("key 2")(a) = fostlib::json(12);
+    fostlib::jcursor("key 2").set(a, 12);
     FSL_CHECK_EQ(a.size(), 2u);
     FSL_CHECK_EQ(a["key 2"], fostlib::json(12));
 }
@@ -90,10 +90,10 @@ FSL_TEST_FUNCTION(replace) {
 
 FSL_TEST_FUNCTION(cow) {
     fostlib::json a = fostlib::json::object_t();
-    fostlib::jcursor("key 2")(a) = fostlib::json("value");
-    fostlib::jcursor("hello")(a) = fostlib::json("goodbye");
+    fostlib::jcursor("key 2").set(a, "value");
+    fostlib::jcursor("hello").set(a, "goodbye");
     fostlib::json b = a;
-    fostlib::jcursor("hello")(b) = fostlib::json("world");
+    fostlib::jcursor("hello").set(b, "world");
     FSL_CHECK_EQ(a["hello"], fostlib::json("goodbye"));
     FSL_CHECK_EQ(b["hello"], fostlib::json("world"));
 }

--- a/Cpp/include/fost/json-core.hpp
+++ b/Cpp/include/fost/json-core.hpp
@@ -274,11 +274,6 @@ namespace fostlib {
         };
 
         template<typename... T>
-        decltype(auto) apply_visitor(T &&... t) {
-            return std::visit(
-                    visitor_overload<T...>(std::forward<T>(t)...), m_element);
-        }
-        template<typename... T>
         decltype(auto) apply_visitor(T &&... t) const {
             return std::visit(
                     visitor_overload<T...>(std::forward<T>(t)...), m_element);
@@ -334,6 +329,15 @@ namespace fostlib {
             res.reserve(s.bytes() + 20); // The 20 is totally arbitrary
             unparse(res, s);
             return string{std::move(res)};
+        }
+
+    private:
+        /// We don't want any code to use the mutating visitor, except
+        /// in contexts we know it to be safe, i.e. here and its friends
+                template<typename... T>
+        decltype(auto) apply_mutating_visitor(T &&... t) {
+            return std::visit(
+                    visitor_overload<T...>(std::forward<T>(t)...), m_element);
         }
     };
 

--- a/Cpp/include/fost/json.hpp
+++ b/Cpp/include/fost/json.hpp
@@ -138,6 +138,7 @@ namespace fostlib {
         /// Copy from the root of the existing `json` to produce a new `json`
         /// instance that can be mutated. Return the head item so it can be
         /// assigned to.
+        [[deprecated("Use the .set() method to alter a json instance")]]
         json &operator()(json &j) const;
 
         /// Push to the back of this location in the passed in `json`


### PR DESCRIPTION
This fixes a bug where pushing back on to an array would cause duplication of items by mutating the array pushed onto rather than a copy as it should be using.

It also tidies up a few problems with the API that need to be fixed up in other places too.